### PR TITLE
Add basic NestJS workspace

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:14-alpine
+ARG NODE_ENV=development
+ARG PORT=3000
+WORKDIR /home/node/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+EXPOSE ${PORT}
+CMD ["node", "dist/main.js"]

--- a/docker/init-mongo.sh
+++ b/docker/init-mongo.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mongo <<EOF_MONGO
+use $MONGO_DATABASE_NAME
+EOF_MONGO

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { AppResolver } from './app.resolver';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot({
+      autoSchemaFile: true,
+    }),
+  ],
+  providers: [AppResolver],
+})
+export class AppModule {}

--- a/src/app.resolver.spec.ts
+++ b/src/app.resolver.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppResolver } from './app.resolver';
+
+describe('AppResolver', () => {
+  let resolver: AppResolver;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AppResolver],
+    }).compile();
+
+    resolver = module.get<AppResolver>(AppResolver);
+  });
+
+  it('should return "Hello World!"', () => {
+    expect(resolver.hello()).toBe('Hello World!');
+  });
+});

--- a/src/app.resolver.ts
+++ b/src/app.resolver.ts
@@ -1,0 +1,9 @@
+import { Query, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class AppResolver {
+  @Query(() => String)
+  hello(): string {
+    return 'Hello World!';
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,10 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const port = process.env.PORT || 3000;
+  await app.listen(port);
+}
+
+bootstrap();


### PR DESCRIPTION
## Summary
- create src directory with basic NestJS GraphQL resolver and module
- add docker files to match existing compose/Makefile

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a56744ed4832f8a3a78bbb95d1d01